### PR TITLE
Fixed a bug in node removal

### DIFF
--- a/src/linked-hash-map.js
+++ b/src/linked-hash-map.js
@@ -273,10 +273,11 @@
 				// it must be the last, need to update
 				this.lastNode = existingNode.prev;
 			}
-			
-			if (existingNode.prev && existingNode.next) {
-				// link them
+			// link them			
+			if (existingNode.prev) {
 				existingNode.prev.next = existingNode.next;
+			}
+			if(existingNode.next) {
 				existingNode.next.prev = existingNode.prev;
 			}
 


### PR DESCRIPTION
Fixed bug in remove method. There is a highly chance that only one of the existingNode.prev or exsistingNode.next become null or valid. Hence, seperating them out to set the respective pointer would always work with all cases.