### PR TITLE
Added overloaded constructor to support empty linked hash map creation

### DIFF
--- a/src/linked-hash-map.js
+++ b/src/linked-hash-map.js
@@ -4,6 +4,11 @@
 	 * A utility that takes advantage on Javascript Object's power as a hashmap, and provide you insertion order.
 	 * Useful if you need to randomly access a value with a key, but need to know who are your immediate neighbours, ie. a carousel.
 	 */
+	
+	LinkedHashMap = function LinkedHashMap() {
+		return this.LinkedHashMap(null);
+	};
+
 	LinkedHashMap = function LinkedHashMap(values) {
 		if (values) {
 			this.putAll(values);


### PR DESCRIPTION
Overloaded constructor to support empty linked hash map creation. This will support the case where we do not have values while creation of the linked hash map.