### PR TITLE
Added support to get value with a provided default value

### DIFF
--- a/src/linked-hash-map.js
+++ b/src/linked-hash-map.js
@@ -170,8 +170,19 @@
 		 * @return The value associated with the key.
 		 */
 		get: function get(key) {
+			return this.getWithDefault(key, null)
+		},
+
+		/**
+		 * Returns value with specified key, or defaultValue if there's no mapping for the key.
+		 * 
+		 * @param key - key with which the specified value is to be associated.
+		 * 
+		 * @return The value associated with the key or the defaultValue passed
+		 */
+		getWithDefault: function getWithDefault(key, defaultValue) {
 			var node = this._getNodes()[key];
-			var value = (node ? node.value : null);
+			var value = (node ? node.value : defaultValue);
 
 			return value;
 		},


### PR DESCRIPTION
Added a overloaded method to support get operation with a default value. This will help to avoid to have null check, cause we can pass the desired default value if the default get operation returns null.